### PR TITLE
Add reference to antenna enclosure alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ https://thewirelesshaven.com/shop/modems-hotspots/invisagig/
 I favor PoE setups so that's probably all you'll see from me
 [4x4 600-6000 MHz QuPanel Directional Antenna Enclosure combo](https://www.quwireless.com/product/qupanel-5glte-global-mimo-4x4-nf?variant=Nf)
 Send them an email, ask for MHF4 connectors inside and you plan to place the modem directly inside the enclosure and power it by PoE so you need an RJ45 bulkhead. 4 3M standoffs and a mounting bracket included. Quoted price should be around $320.
+An alternative antenna enclosure is [Ponyting EPNT-2](https://poynting.tech/antennas/epnt-2/) at around $250. It has 4x4 MIMO for sub 6Ghz 5G and 2x2 MIMO for WiFi.
+
+
 
 Using the MCUZone PoE version: https://a.aliexpress.com/_mrUgImG for this. It doesn't come bundled with an RM520 or 21 so you'll need one too: https://a.aliexpress.com/_mKawdfE
 


### PR DESCRIPTION
The Poynting enclosure seems to be available off-the-shelf without custom order. I'm not an expert on antenna designs / characteristics, but the performance plots look quite similar.

Disadvantage seems to be that Poynting is only up to 4.2 Ghz, but this seems to be only relevant for Japan (4.5 - 4.9 Ghz) and China (4.8 - 5 Ghz). EU, Korea and US have a unlicensed range available at 5.9 Ghz+ so there is also not advantage in the QuPanel 6Ghz Ultrawide band.